### PR TITLE
Fix chroma test

### DIFF
--- a/chroma_test.py
+++ b/chroma_test.py
@@ -1,6 +1,7 @@
 from constants import *
 from chromadb.utils import embedding_functions
 from vlite2.utils import chop_and_chunk
+from vlite2.model import EmbeddingModel
 import time
 import timeit
 import pandas as pd
@@ -8,26 +9,26 @@ from openpyxl import load_workbook
 import xlsxwriter
 import os
 
-default_ef = embedding_functions.DefaultEmbeddingFunction()
+embedding_model = EmbeddingModel()
 
 def ingest_one_cdb(cdb):
-    cdb.add(
+    cdb.upsert(
         documents = [SHORT_DATA],
-        embeddings = default_ef([SHORT_DATA]),
+        embeddings = embedding_model.embed(texts=SHORT_DATA),
         ids = ["id0"],
     )
 
 def retrieve_cdb(cdb, text):
     results = cdb.query(
-        query_embeddings=default_ef(text),
+        query_embeddings=embedding_model.embed(texts=[text]),
         n_results=k
     )
 
 def ingest_many_cdb(cdb):
     long_data_chunked = chop_and_chunk(LONG_DATA, 512)
-    cdb.add(
+    cdb.upsert(
         documents = long_data_chunked,
-        embeddings = default_ef(long_data_chunked),
+        embeddings = embedding_model.embed(texts=long_data_chunked),
         ids = ["id"+str(i) for i in range(len(long_data_chunked))],
     )
 


### PR DESCRIPTION
`chroma_test.py` had a bug where elements with the same ids were attempted to be inserted into a collection which already had elements with those ids. 

The behavior in chroma on `.add` of an element with an id which already exists is to reject the add and warn the user. see the docs here: https://docs.trychroma.com/usage-guide#adding-data-to-a-collection

The fix is to change all instances of `.add` to `.upsert`. this is a little slower than what a raw `.add` would be since we do a delete as well as an add, but it's the fastest way to fix this test. 

Additionally, most of the time spent in the original test was spent in Chroma's default embedding function, which isn't mps or cuda enabled. To make the test fairer, we use the same embedding function as the other tests. 